### PR TITLE
Add tgenv makefile release target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ versions/
 version
 .terragrunt-version
 bin/terragrunt-*
+dist
 ## Mac things
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 PKG_NAME := "tgenv-affirm"
 
 release:
-	@which gh >/dev/null || >&2 echo "Please install gh CLI with \"brew install gh\""; exit 1
-	@which brew >/dev/null || >&2 echo "Please install Homebrew https://brew.sh/"; exit 1
+	@which gh >/dev/null || (>&2 echo "Please install gh CLI with \"brew install gh\"" && exit 1)
+	@which brew >/dev/null || (echo "Please install Homebrew https://brew.sh/" && exit 1)
 ifndef RELEASE
 	$(error "RELEASE env var is undefined")
 endif
@@ -16,6 +16,6 @@ endif
 	@mkdir -p ./dist
 	@tar --exclude-from .gitignore --exclude-vcs -czvf "./dist/$(PKG_NAME).tar.gz" *
 	@sha256sum "./dist/$(PKG_NAME).tar.gz"
-	@gh release create --repo Affirm/tgenv "$$RELEASE" --verify-tag "./dist/$(PKG_NAME).tar.gz"
-	@echo "Please update brew formula url and sha256"
+	@gh release create --repo Affirm/tgenv --title "$$RELEASE" --notes-file CHANGELOG.md --verify-tag "$$RELEASE" "./dist/$(PKG_NAME).tar.gz" || >&2 echo "Release $$RELEASE already exists, doing nothing"
+	@echo "Please update brew formula: url and sha256"
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 	@echo "Creating release for $$RELEASE"
 	@git tag "$$RELEASE" || >&2 echo "Tag $$RELEASE already exists, creating release for tag"
 	@mkdir -p ./dist
-	@tar -czvf "./dist/$(PKG_NAME).tar.gz" .* --exclude ./dist
+	@tar --exclude-from .gitignore --exclude-vcs -czvf "./dist/$(PKG_NAME).tar.gz" *
 	@sha256sum "./dist/$(PKG_NAME).tar.gz"
 	@gh release create --repo Affirm/tgenv "$$RELEASE" --verify-tag "./dist/$(PKG_NAME).tar.gz"
 	@echo "Please update brew formula url and sha256"

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 PKG_NAME := "tgenv-affirm"
 
 release:
-	@which gh >/dev/null || >&2 echo "Please install gh CLI with \"brew install gh\""
-	@which brew >/dev/null || >&2 echo "Please install Homebrew https://brew.sh/"
+	@which gh >/dev/null || >&2 echo "Please install gh CLI with \"brew install gh\""; exit 1
+	@which brew >/dev/null || >&2 echo "Please install Homebrew https://brew.sh/"; exit 1
 ifndef RELEASE
 	$(error "RELEASE env var is undefined")
 endif
@@ -12,7 +12,7 @@ ifndef PKG_NAME
 	$(error "PKG_NAME makefile var is undefined")
 endif
 	@echo "Creating release for $$RELEASE"
-	@git tag "$$RELEASE" || >&2 echo "Tag $$RELEASE already exists, creating release for tag"
+	@git tag "$$RELEASE" && git push origin "$$RELEASE" || >&2 echo "Tag $$RELEASE already exists, creating release for tag"
 	@mkdir -p ./dist
 	@tar --exclude-from .gitignore --exclude-vcs -czvf "./dist/$(PKG_NAME).tar.gz" *
 	@sha256sum "./dist/$(PKG_NAME).tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: release
+
+PKG_NAME := "tgenv-affirm"
+
+release:
+	@which gh >/dev/null || >&2 echo "Please install gh CLI with \"brew install gh\""
+	@which brew >/dev/null || >&2 echo "Please install Homebrew https://brew.sh/"
+ifndef RELEASE
+	$(error "RELEASE env var is undefined")
+endif
+ifndef PKG_NAME
+	$(error "PKG_NAME makefile var is undefined")
+endif
+	@echo "Creating release for $$RELEASE"
+	@git tag "$$RELEASE" || >&2 echo "Tag $$RELEASE already exists, creating release for tag"
+	@mkdir -p ./dist
+	@tar -czvf "./dist/$(PKG_NAME).tar.gz" .* --exclude ./dist
+	@sha256sum "./dist/$(PKG_NAME).tar.gz"
+	@gh release create --repo Affirm/tgenv "$$RELEASE" --verify-tag "./dist/$(PKG_NAME).tar.gz"
+	@echo "Please update brew formula url and sha256"
+


### PR DESCRIPTION
## Why? 🤔

This will make it much easier to create a release.

## What? :hammer_and_wrench:

Adding a Makefile target to create a git tag and release.

Makefile output:
```
> RELEASE=v0.2.1 make release
Creating release for v0.2.1
fatal: tag 'v0.2.1' already exists
Tag v0.2.1 already exists, creating release for tag
a CHANGELOG.md
a LICENSE
a Makefile
a README.md
a assets
a assets/tgenv-logo.png
a bin
a bin/terragrunt
a bin/tgenv
a libexec
a libexec/tgenv---version
a libexec/tgenv-list-remote
a libexec/tgenv-use
a libexec/tgenv-version-file
a libexec/tgenv-uninstall
a libexec/tgenv-upgrade
a libexec/tgenv-install
a libexec/tgenv-list
a libexec/tgenv-exec
a libexec/tgenv-version-name
a libexec/helpers
a libexec/tgenv-help
a list_all_versions_offline
a test
a test/helpers.sh
a test/setup_runner.sh
a test/run.sh
a test/test_symlink.sh
a test/install_deps.sh
a test/test_uninstall.sh
a test/test_list.sh
a test/test_install_and_use.sh
51dadf7b7965a67dd51376ad4fa08611ab98970c3af77c515ca7a018c8b08485  ./dist/tgenv-affirm.tar.gz
a release with the same tag name already exists: v0.2.1
Release v0.2.1 already exists, doing nothing
Please update brew formula: url and sha256
```